### PR TITLE
Add MCP Server documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -170,7 +170,6 @@
             "group": "SDK Documentation",
             "pages": [
               "sdk/getting-started",
-              "sdk/mcp-server",
               "sdk/create-dataset-sdk",
               "sdk/create-project-sdk",
               "sdk/add-annotation-questions",
@@ -180,6 +179,12 @@
               "sdk/create-export-sdk",
               "sdk/magic-wand-confidence-filtering",
               "sdk/changelog"
+            ]
+          },
+          {
+            "group": "MCP Server",
+            "pages": [
+              "sdk/mcp-server"
             ]
           }
         ]

--- a/docs.json
+++ b/docs.json
@@ -170,6 +170,7 @@
             "group": "SDK Documentation",
             "pages": [
               "sdk/getting-started",
+              "sdk/mcp-server",
               "sdk/create-dataset-sdk",
               "sdk/create-project-sdk",
               "sdk/add-annotation-questions",

--- a/sdk/mcp-server.mdx
+++ b/sdk/mcp-server.mdx
@@ -1,0 +1,326 @@
+---
+title: "MCP Server"
+description: "Use Labellerr with AI assistants like Claude and Cursor through the Model Context Protocol (MCP) server for natural language data annotation workflows."
+icon: robot
+---
+
+## Introduction
+
+The **Labellerr MCP Server** enables you to interact with the Labellerr platform using natural language through AI assistants like **Claude Desktop** and **Cursor**. Built on the Model Context Protocol (MCP), it provides 23 tools for managing datasets, projects, annotations, and exports conversationally.
+
+<Note>
+  **Pure API Implementation** - The MCP server uses direct REST API calls, completely independent of the SDK, ensuring lightweight and reliable operation.
+</Note>
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+- Python 3.8 or higher
+- Labellerr API credentials (API Key, API Secret, Client ID)
+- Claude Desktop or Cursor installed
+
+### Installation
+
+```bash Install MCP Server
+cd /path/to/SDKPython
+pip install -r requirements.txt
+```
+
+### Configuration
+
+<Tabs>
+  <Tab title="Cursor">
+    Add to `~/.cursor/mcp.json`:
+
+```json Cursor Configuration
+{
+  "mcpServers": {
+    "labellerr": {
+      "command": "python3",
+      "args": ["/FULL/PATH/TO/SDKPython/labellerr/mcp_server/server.py"],
+      "env": {
+        "LABELLERR_API_KEY": "your_api_key",
+        "LABELLERR_API_SECRET": "your_api_secret",
+        "LABELLERR_CLIENT_ID": "your_client_id"
+      }
+    }
+  }
+}
+```
+  </Tab>
+  
+  <Tab title="Claude Desktop">
+    Add to Claude Desktop config:
+    - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+    - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json Claude Desktop Configuration
+{
+  "mcpServers": {
+    "labellerr": {
+      "command": "python3",
+      "args": ["/FULL/PATH/TO/SDKPython/labellerr/mcp_server/server.py"],
+      "env": {
+        "LABELLERR_API_KEY": "your_api_key",
+        "LABELLERR_API_SECRET": "your_api_secret",
+        "LABELLERR_CLIENT_ID": "your_client_id"
+      }
+    }
+  }
+}
+```
+  </Tab>
+</Tabs>
+
+<Warning>
+  **Important**: Use the absolute path to `server.py`. Restart your AI assistant completely after configuration.
+</Warning>
+
+---
+
+## Available Tools
+
+The MCP server provides 23 tools organized into 5 categories:
+
+### Project Management (4 tools)
+
+| Tool | Description |
+|------|-------------|
+| `project_create` | Create a new annotation project (requires dataset_id and template_id) |
+| `project_list` | List all projects in your workspace |
+| `project_get` | Get detailed information about a specific project |
+| `project_update_rotation` | Update annotation rotation configuration |
+
+### Dataset Management (5 tools)
+
+| Tool | Description |
+|------|-------------|
+| `dataset_create` | Create dataset with automatic file upload and status polling |
+| `dataset_upload_files` | Upload individual files to create a dataset |
+| `dataset_upload_folder` | Upload an entire folder of files |
+| `dataset_list` | List all datasets with filtering options |
+| `dataset_get` | Get detailed information about a dataset |
+
+### Annotation Operations (6 tools)
+
+| Tool | Description |
+|------|-------------|
+| `template_create` | Create annotation template with questions/guidelines |
+| `annotation_export` | Export project annotations in various formats |
+| `annotation_check_export_status` | Check status of export jobs |
+| `annotation_download_export` | Get download URL for completed exports |
+| `annotation_upload_preannotations` | Upload pre-annotations (synchronous) |
+| `annotation_upload_preannotations_async` | Upload pre-annotations (asynchronous) |
+
+### Monitoring Tools (4 tools)
+
+| Tool | Description |
+|------|-------------|
+| `monitor_system_health` | Check MCP server health and connection status |
+| `monitor_active_operations` | List all active operations and their status |
+| `monitor_project_progress` | Get progress statistics for a project |
+| `monitor_job_status` | Monitor background job status |
+
+### Query Tools (4 tools)
+
+| Tool | Description |
+|------|-------------|
+| `query_project_statistics` | Get detailed statistics for a project |
+| `query_dataset_info` | Get detailed information about a dataset |
+| `query_operation_history` | Query history of operations performed |
+| `query_search_projects` | Search for projects by name or type |
+
+---
+
+## Usage Examples
+
+### Create a Complete Project
+
+Simply talk to your AI assistant naturally:
+
+```
+Create an image annotation project called "Product Detection" with 
+bounding boxes for "Product" and "Defect". Upload images from 
+/Users/me/products and use my email user@example.com
+```
+
+The MCP server will:
+1. Upload images from the folder
+2. Create a dataset
+3. Create an annotation template with bounding box questions
+4. Create and link the project
+
+### Check Project Status
+
+```
+What's the progress on all my annotation projects?
+```
+
+### Export Annotations
+
+```
+Export all accepted annotations from project abc123 in COCO JSON format
+```
+
+### Upload More Data
+
+```
+Upload images from /Users/me/more-data to dataset xyz789
+```
+
+---
+
+## Three-Step Workflow
+
+The MCP server enforces an explicit three-step workflow for project creation:
+
+<Steps>
+  <Step title="Create Dataset">
+    Upload files and create a dataset:
+    ```
+    Create a dataset called "Training Data" from folder /path/to/images
+    ```
+  </Step>
+  
+  <Step title="Create Template">
+    Define annotation questions:
+    ```
+    Create an annotation template with bounding boxes for "Car" and "Truck"
+    ```
+  </Step>
+  
+  <Step title="Create Project">
+    Link dataset and template:
+    ```
+    Create a project using dataset [dataset_id] and template [template_id]
+    ```
+  </Step>
+</Steps>
+
+This ensures proper resource management and clear project structure.
+
+---
+
+## Supported Data Types
+
+All tools support multiple data types:
+
+- **image** - JPG, PNG, TIFF
+- **video** - MP4
+- **audio** - MP3, WAV
+- **document** - PDF
+- **text** - TXT
+
+---
+
+## Export Formats
+
+Annotations can be exported in multiple formats:
+
+- **json** - Labellerr native format
+- **coco_json** - COCO dataset format
+- **csv** - Comma-separated values
+- **png** - Segmentation masks (for segmentation projects)
+
+---
+
+## Error Handling
+
+The MCP server provides clear error messages:
+
+```
+Error: dataset_id is required
+Message: Please create a dataset first using dataset_upload_folder
+```
+
+All operations are logged in the operation history, accessible via:
+
+```
+Show me the history of operations I've performed
+```
+
+---
+
+## Troubleshooting
+
+### AI Assistant Doesn't Show Tools
+
+1. Completely restart your AI assistant (quit and reopen)
+2. Verify the path is absolute (starts with `/` or `C:\`)
+3. Test manually: `python3 /path/to/server.py`
+
+### Authentication Errors
+
+1. Get fresh credentials from your Labellerr workspace
+2. Update the config file with correct credentials
+3. Restart your AI assistant
+
+### File Upload Issues
+
+- Ensure file paths are absolute
+- Check file permissions
+- Verify supported file formats for your data type
+
+---
+
+## Advanced Features
+
+### Operation History
+
+The server tracks all operations with timestamps, durations, and status:
+
+```
+Show me failed operations from the last hour
+```
+
+### Resource Caching
+
+Active projects and datasets are cached for faster access. View cached resources:
+
+```
+What Labellerr resources are currently active?
+```
+
+### Status Polling
+
+Dataset creation automatically polls for processing completion with configurable timeout:
+
+```python
+dataset_create(
+  folder_path="/path/to/data",
+  wait_for_processing=True,
+  processing_timeout=300  # 5 minutes
+)
+```
+
+---
+
+## API Reference
+
+For detailed API documentation, see:
+- [GitHub Repository](https://github.com/Labellerr/SDKPython)
+- [MCP Server README](https://github.com/Labellerr/SDKPython/blob/main/labellerr/mcp_server/README.md)
+- [API Documentation](https://api.labellerr.com/docs)
+
+---
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="SDK Documentation" icon="code" href="/sdk/getting-started">
+    Learn about the Python SDK for programmatic access
+  </Card>
+  <Card title="Create Projects" icon="folder-plus" href="/sdk/create-project-sdk">
+    Detailed guide on creating annotation projects
+  </Card>
+  <Card title="Export Data" icon="download" href="/sdk/create-export-sdk">
+    Learn how to export your annotated data
+  </Card>
+  <Card title="Cookbooks" icon="book" href="/cookbooks/sdk-tutorials">
+    Practical examples and tutorials
+  </Card>
+</CardGroup>
+

--- a/sdk/mcp-server.mdx
+++ b/sdk/mcp-server.mdx
@@ -6,26 +6,30 @@ icon: robot
 
 ## Introduction
 
-The **Labellerr MCP Server** enables you to interact with the Labellerr platform using natural language through AI assistants like **Claude Desktop** and **Cursor**. Built on the Model Context Protocol (MCP), it provides 23 tools for managing datasets, projects, annotations, and exports conversationally.
+The **Labellerr MCP Server** enables seamless interaction with the Labellerr platform using natural language through AI assistants such as **Claude Desktop** and **Cursor**. Built on the Model Context Protocol (MCP), it provides 23 comprehensive tools for managing datasets, projects, annotations, and exports through conversational interfaces.
 
-<Note>
-  **Pure API Implementation** - The MCP server uses direct REST API calls, completely independent of the SDK, ensuring lightweight and reliable operation.
-</Note>
-
----
 
 ## Quick Start
 
 ### Prerequisites
 
 - Python 3.8 or higher
-- Labellerr API credentials (API Key, API Secret, Client ID)
+- Git installed on your system
+- Labellerr API credentials (API Key, API Secret, Client ID) - [Get your credentials](https://docs.labellerr.com/sdk/getting-started#obtaining-api-credentials)
 - Claude Desktop or Cursor installed
 
 ### Installation
 
-```bash Install MCP Server
-cd /path/to/SDKPython
+First, clone the SDKPython repository:
+
+```bash Clone Repository
+git clone https://github.com/Labellerr/SDKPython.git
+cd SDKPython
+```
+
+Then install the required dependencies:
+
+```bash Install Dependencies
 pip install -r requirements.txt
 ```
 
@@ -79,14 +83,12 @@ pip install -r requirements.txt
   **Important**: Use the absolute path to `server.py`. Restart your AI assistant completely after configuration.
 </Warning>
 
----
-
 ## Available Tools
 
-The MCP server provides **23 powerful tools** organized into 5 categories to manage your entire annotation workflow:
+The MCP server provides **23 comprehensive tools** organized into 5 functional categories to manage your complete annotation workflow:
 
 <AccordionGroup>
-  <Accordion title="📁 Project Management (4 tools)" icon="folder-tree">
+  <Accordion title="Project Management (4 tools)" icon="folder-tree">
     <ResponseField name="project_create" type="tool">
       Create a new annotation project (requires dataset_id and template_id)
     </ResponseField>
@@ -101,7 +103,7 @@ The MCP server provides **23 powerful tools** organized into 5 categories to man
     </ResponseField>
   </Accordion>
 
-  <Accordion title="💾 Dataset Management (5 tools)" icon="database">
+  <Accordion title="Dataset Management (5 tools)" icon="database">
     <ResponseField name="dataset_create" type="tool">
       Create dataset with automatic file upload and status polling
     </ResponseField>
@@ -119,7 +121,7 @@ The MCP server provides **23 powerful tools** organized into 5 categories to man
     </ResponseField>
   </Accordion>
 
-  <Accordion title="✏️ Annotation Operations (6 tools)" icon="pen-to-square">
+  <Accordion title="Annotation Operations (6 tools)" icon="pen-to-square">
     <ResponseField name="template_create" type="tool">
       Create annotation template with questions/guidelines
     </ResponseField>
@@ -140,7 +142,7 @@ The MCP server provides **23 powerful tools** organized into 5 categories to man
     </ResponseField>
   </Accordion>
 
-  <Accordion title="📊 Monitoring Tools (4 tools)" icon="chart-line">
+  <Accordion title="Monitoring Tools (4 tools)" icon="chart-line">
     <ResponseField name="monitor_system_health" type="tool">
       Check MCP server health and connection status
     </ResponseField>
@@ -155,7 +157,7 @@ The MCP server provides **23 powerful tools** organized into 5 categories to man
     </ResponseField>
   </Accordion>
 
-  <Accordion title="🔍 Query Tools (4 tools)" icon="magnifying-glass">
+  <Accordion title="Query Tools (4 tools)" icon="magnifying-glass">
     <ResponseField name="query_project_statistics" type="tool">
       Get detailed statistics for a project
     </ResponseField>
@@ -171,13 +173,11 @@ The MCP server provides **23 powerful tools** organized into 5 categories to man
   </Accordion>
 </AccordionGroup>
 
----
-
 ## Usage Examples
 
-### Create a Complete Project
+Interact with the MCP server using natural language commands through your AI assistant. Below are common usage patterns:
 
-Simply talk to your AI assistant naturally:
+### Create a Complete Project
 
 ```
 Create an image annotation project called "Product Detection" with 
@@ -185,13 +185,13 @@ bounding boxes for "Product" and "Defect". Upload images from
 /Users/me/products and use my email user@example.com
 ```
 
-The MCP server will:
-1. Upload images from the folder
-2. Create a dataset
-3. Create an annotation template with bounding box questions
-4. Create and link the project
+**Automated workflow:**
+1. Upload images from the specified folder
+2. Create a dataset with uploaded files
+3. Generate an annotation template with bounding box questions
+4. Create and link the project with all resources
 
-### Check Project Status
+### Monitor Project Progress
 
 ```
 What's the progress on all my annotation projects?
@@ -203,30 +203,28 @@ What's the progress on all my annotation projects?
 Export all accepted annotations from project abc123 in COCO JSON format
 ```
 
-### Upload More Data
+### Upload Additional Data
 
 ```
 Upload images from /Users/me/more-data to dataset xyz789
 ```
 
----
+## Project Creation Workflow
 
-## Three-Step Workflow
-
-The MCP server uses an intelligent **three-step workflow** for project creation. When you ask to create a complete project, the server **automatically executes all three steps** for you:
+The MCP server implements a structured three-step workflow for creating annotation projects. When you request a complete project, the server automatically executes all steps in sequence.
 
 <Info>
-  **Smart Automation**: Simply describe what you want, and the MCP server handles the entire workflow automatically!
+  **Automated Workflow**: Describe your requirements in natural language, and the MCP server handles the complete workflow automatically.
 </Info>
 
 <Steps>
   <Step title="Step 1: Create Dataset" icon="database">
     The server uploads your files and creates a dataset.
     
-    **What happens:**
+    **Process:**
     - Files are uploaded to cloud storage
     - Dataset is created and linked
-    - Processing status is monitored until ready
+    - Processing status is monitored until completion
     
     **Example request:**
     ```
@@ -235,16 +233,16 @@ The MCP server uses an intelligent **three-step workflow** for project creation.
     
     **Server response:**
     ```
-    ✓ Uploaded 150 images
-    ✓ Dataset created: dataset_abc123
-    ✓ Dataset ready for annotation
+    Uploaded 150 images
+    Dataset created: dataset_abc123
+    Dataset ready for annotation
     ```
   </Step>
   
   <Step title="Step 2: Create Template" icon="pen-to-square">
     The server creates an annotation template with your specified questions.
     
-    **What happens:**
+    **Process:**
     - Annotation questions are defined
     - Question types are configured (BoundingBox, polygon, etc.)
     - Template is validated and saved
@@ -256,15 +254,15 @@ The MCP server uses an intelligent **three-step workflow** for project creation.
     
     **Server response:**
     ```
-    ✓ Template created: template_xyz789
-    ✓ Questions: Car (BoundingBox), Truck (BoundingBox)
+    Template created: template_xyz789
+    Questions: Car (BoundingBox), Truck (BoundingBox)
     ```
   </Step>
   
   <Step title="Step 3: Create Project" icon="folder-plus">
     The server links the dataset and template to create your project.
     
-    **What happens:**
+    **Process:**
     - Dataset and template are validated
     - Project is created with proper configuration
     - Resources are linked and ready for annotation
@@ -276,16 +274,16 @@ The MCP server uses an intelligent **three-step workflow** for project creation.
     
     **Server response:**
     ```
-    ✓ Project created: project_final_456
-    ✓ Linked dataset: dataset_abc123 (150 files)
-    ✓ Linked template: template_xyz789
-    ✓ Ready to start annotation!
+    Project created: project_final_456
+    Linked dataset: dataset_abc123 (150 files)
+    Linked template: template_xyz789
+    Ready to start annotation
     ```
   </Step>
 </Steps>
 
 <Tip>
-  **All-in-One Command**: You can also create everything in one natural language request:
+  **Unified Command**: You can create everything in one natural language request:
   
   ```
   Create an image annotation project called "Vehicle Detection" with 
@@ -293,76 +291,78 @@ The MCP server uses an intelligent **three-step workflow** for project creation.
   /Users/me/vehicles and use my email user@example.com
   ```
   
-  The MCP server will automatically execute all three steps and provide you with the final project ID!
+  The MCP server will automatically execute all three steps and provide you with the final project ID.
 </Tip>
 
-This workflow ensures:
-- ✅ Proper resource management
-- ✅ Clear project structure
-- ✅ Validation at each step
-- ✅ Automatic error handling
-
----
+**Workflow Benefits:**
+- Proper resource management
+- Clear project structure
+- Validation at each step
+- Automatic error handling
 
 ## Supported Data Types
 
-All tools support multiple data types:
+The MCP server supports the following data types across all tools:
 
-- **image** - JPG, PNG, TIFF
-- **video** - MP4
-- **audio** - MP3, WAV
-- **document** - PDF
-- **text** - TXT
-
----
+| Data Type | Supported Formats |
+|-----------|------------------|
+| **Image** | JPG, PNG, TIFF |
+| **Video** | MP4 |
+| **Audio** | MP3, WAV |
+| **Document** | PDF |
+| **Text** | TXT |
 
 ## Export Formats
 
-Annotations can be exported in multiple formats:
+Annotations can be exported in multiple industry-standard formats:
 
-- **json** - Labellerr native format
-- **coco_json** - COCO dataset format
-- **csv** - Comma-separated values
-- **png** - Segmentation masks (for segmentation projects)
-
----
+| Format | Description |
+|--------|-------------|
+| **json** | Labellerr native format with complete annotation metadata |
+| **coco_json** | COCO dataset format for computer vision tasks |
+| **csv** | Comma-separated values for tabular data analysis |
+| **png** | Segmentation masks for pixel-level annotations |
 
 ## Error Handling
 
-The MCP server provides clear error messages:
+The MCP server provides descriptive error messages to help diagnose and resolve issues:
 
 ```
 Error: dataset_id is required
 Message: Please create a dataset first using dataset_upload_folder
 ```
 
-All operations are logged in the operation history, accessible via:
+All operations are logged in the operation history and can be queried using natural language:
 
 ```
 Show me the history of operations I've performed
 ```
 
----
-
 ## Troubleshooting
 
 ### AI Assistant Doesn't Show Tools
 
-1. Completely restart your AI assistant (quit and reopen)
-2. Verify the path is absolute (starts with `/` or `C:\`)
-3. Test manually: `python3 /path/to/server.py`
+**Resolution steps:**
+1. Completely restart your AI assistant (quit and reopen the application)
+2. Verify the path to `server.py` is absolute (starts with `/` on macOS/Linux or `C:\` on Windows)
+3. Test the server manually: `python3 /path/to/server.py`
+4. Check the MCP configuration file for syntax errors
 
 ### Authentication Errors
 
-1. Get fresh credentials from your Labellerr workspace
-2. Update the config file with correct credentials
-3. Restart your AI assistant
+**Resolution steps:**
+1. Obtain fresh credentials from your Labellerr workspace
+2. Update the configuration file with the correct API credentials
+3. Ensure all three credentials (API Key, API Secret, Client ID) are present
+4. Restart your AI assistant after updating credentials
 
 ### File Upload Issues
 
-- Ensure file paths are absolute
-- Check file permissions
-- Verify supported file formats for your data type
+**Common causes and solutions:**
+- Verify file paths are absolute, not relative
+- Check file system permissions for read access
+- Confirm file formats match the specified data type
+- Ensure sufficient disk space for upload operations
 
 ---
 
@@ -370,7 +370,7 @@ Show me the history of operations I've performed
 
 ### Operation History
 
-The server tracks all operations with timestamps, durations, and status:
+The server maintains a comprehensive log of all operations with timestamps, durations, and status information. Query the operation history using natural language:
 
 ```
 Show me failed operations from the last hour
@@ -378,7 +378,7 @@ Show me failed operations from the last hour
 
 ### Resource Caching
 
-Active projects and datasets are cached for faster access. View cached resources:
+Active projects and datasets are cached in memory for improved performance and faster access. View currently cached resources:
 
 ```
 What Labellerr resources are currently active?
@@ -386,7 +386,7 @@ What Labellerr resources are currently active?
 
 ### Status Polling
 
-Dataset creation automatically polls for processing completion with configurable timeout:
+Dataset creation includes automatic status polling to monitor processing completion. Configure timeout settings as needed:
 
 ```python
 dataset_create(
@@ -396,16 +396,13 @@ dataset_create(
 )
 ```
 
----
+## Additional Resources
 
-## API Reference
+For comprehensive documentation and technical references:
 
-For detailed API documentation, see:
-- [GitHub Repository](https://github.com/Labellerr/SDKPython)
-- [MCP Server README](https://github.com/Labellerr/SDKPython/blob/main/labellerr/mcp_server/README.md)
-- [API Documentation](https://api.labellerr.com/docs)
-
----
+- **[GitHub Repository](https://github.com/Labellerr/SDKPython)** - Source code and examples
+- **[MCP Server README](https://github.com/Labellerr/SDKPython/blob/main/labellerr/mcp_server/README.md)** - Detailed server documentation
+- **[API Documentation](https://api.labellerr.com/docs)** - Complete API reference
 
 ## Next Steps
 

--- a/sdk/mcp-server.mdx
+++ b/sdk/mcp-server.mdx
@@ -83,55 +83,93 @@ pip install -r requirements.txt
 
 ## Available Tools
 
-The MCP server provides 23 tools organized into 5 categories:
+The MCP server provides **23 powerful tools** organized into 5 categories to manage your entire annotation workflow:
 
-### Project Management (4 tools)
+<AccordionGroup>
+  <Accordion title="📁 Project Management (4 tools)" icon="folder-tree">
+    <ResponseField name="project_create" type="tool">
+      Create a new annotation project (requires dataset_id and template_id)
+    </ResponseField>
+    <ResponseField name="project_list" type="tool">
+      List all projects in your workspace
+    </ResponseField>
+    <ResponseField name="project_get" type="tool">
+      Get detailed information about a specific project
+    </ResponseField>
+    <ResponseField name="project_update_rotation" type="tool">
+      Update annotation rotation configuration
+    </ResponseField>
+  </Accordion>
 
-| Tool | Description |
-|------|-------------|
-| `project_create` | Create a new annotation project (requires dataset_id and template_id) |
-| `project_list` | List all projects in your workspace |
-| `project_get` | Get detailed information about a specific project |
-| `project_update_rotation` | Update annotation rotation configuration |
+  <Accordion title="💾 Dataset Management (5 tools)" icon="database">
+    <ResponseField name="dataset_create" type="tool">
+      Create dataset with automatic file upload and status polling
+    </ResponseField>
+    <ResponseField name="dataset_upload_files" type="tool">
+      Upload individual files to create a dataset
+    </ResponseField>
+    <ResponseField name="dataset_upload_folder" type="tool">
+      Upload an entire folder of files
+    </ResponseField>
+    <ResponseField name="dataset_list" type="tool">
+      List all datasets with filtering options
+    </ResponseField>
+    <ResponseField name="dataset_get" type="tool">
+      Get detailed information about a dataset
+    </ResponseField>
+  </Accordion>
 
-### Dataset Management (5 tools)
+  <Accordion title="✏️ Annotation Operations (6 tools)" icon="pen-to-square">
+    <ResponseField name="template_create" type="tool">
+      Create annotation template with questions/guidelines
+    </ResponseField>
+    <ResponseField name="annotation_export" type="tool">
+      Export project annotations in various formats (JSON, COCO, CSV, PNG)
+    </ResponseField>
+    <ResponseField name="annotation_check_export_status" type="tool">
+      Check status of export jobs
+    </ResponseField>
+    <ResponseField name="annotation_download_export" type="tool">
+      Get download URL for completed exports
+    </ResponseField>
+    <ResponseField name="annotation_upload_preannotations" type="tool">
+      Upload pre-annotations (synchronous)
+    </ResponseField>
+    <ResponseField name="annotation_upload_preannotations_async" type="tool">
+      Upload pre-annotations (asynchronous)
+    </ResponseField>
+  </Accordion>
 
-| Tool | Description |
-|------|-------------|
-| `dataset_create` | Create dataset with automatic file upload and status polling |
-| `dataset_upload_files` | Upload individual files to create a dataset |
-| `dataset_upload_folder` | Upload an entire folder of files |
-| `dataset_list` | List all datasets with filtering options |
-| `dataset_get` | Get detailed information about a dataset |
+  <Accordion title="📊 Monitoring Tools (4 tools)" icon="chart-line">
+    <ResponseField name="monitor_system_health" type="tool">
+      Check MCP server health and connection status
+    </ResponseField>
+    <ResponseField name="monitor_active_operations" type="tool">
+      List all active operations and their status
+    </ResponseField>
+    <ResponseField name="monitor_project_progress" type="tool">
+      Get progress statistics for a project
+    </ResponseField>
+    <ResponseField name="monitor_job_status" type="tool">
+      Monitor background job status
+    </ResponseField>
+  </Accordion>
 
-### Annotation Operations (6 tools)
-
-| Tool | Description |
-|------|-------------|
-| `template_create` | Create annotation template with questions/guidelines |
-| `annotation_export` | Export project annotations in various formats |
-| `annotation_check_export_status` | Check status of export jobs |
-| `annotation_download_export` | Get download URL for completed exports |
-| `annotation_upload_preannotations` | Upload pre-annotations (synchronous) |
-| `annotation_upload_preannotations_async` | Upload pre-annotations (asynchronous) |
-
-### Monitoring Tools (4 tools)
-
-| Tool | Description |
-|------|-------------|
-| `monitor_system_health` | Check MCP server health and connection status |
-| `monitor_active_operations` | List all active operations and their status |
-| `monitor_project_progress` | Get progress statistics for a project |
-| `monitor_job_status` | Monitor background job status |
-
-### Query Tools (4 tools)
-
-| Tool | Description |
-|------|-------------|
-| `query_project_statistics` | Get detailed statistics for a project |
-| `query_dataset_info` | Get detailed information about a dataset |
-| `query_operation_history` | Query history of operations performed |
-| `query_search_projects` | Search for projects by name or type |
+  <Accordion title="🔍 Query Tools (4 tools)" icon="magnifying-glass">
+    <ResponseField name="query_project_statistics" type="tool">
+      Get detailed statistics for a project
+    </ResponseField>
+    <ResponseField name="query_dataset_info" type="tool">
+      Get detailed information about a dataset
+    </ResponseField>
+    <ResponseField name="query_operation_history" type="tool">
+      Query history of operations performed
+    </ResponseField>
+    <ResponseField name="query_search_projects" type="tool">
+      Search for projects by name or type
+    </ResponseField>
+  </Accordion>
+</AccordionGroup>
 
 ---
 
@@ -175,32 +213,94 @@ Upload images from /Users/me/more-data to dataset xyz789
 
 ## Three-Step Workflow
 
-The MCP server enforces an explicit three-step workflow for project creation:
+The MCP server uses an intelligent **three-step workflow** for project creation. When you ask to create a complete project, the server **automatically executes all three steps** for you:
+
+<Info>
+  **Smart Automation**: Simply describe what you want, and the MCP server handles the entire workflow automatically!
+</Info>
 
 <Steps>
-  <Step title="Create Dataset">
-    Upload files and create a dataset:
+  <Step title="Step 1: Create Dataset" icon="database">
+    The server uploads your files and creates a dataset.
+    
+    **What happens:**
+    - Files are uploaded to cloud storage
+    - Dataset is created and linked
+    - Processing status is monitored until ready
+    
+    **Example request:**
     ```
     Create a dataset called "Training Data" from folder /path/to/images
     ```
+    
+    **Server response:**
+    ```
+    ✓ Uploaded 150 images
+    ✓ Dataset created: dataset_abc123
+    ✓ Dataset ready for annotation
+    ```
   </Step>
   
-  <Step title="Create Template">
-    Define annotation questions:
+  <Step title="Step 2: Create Template" icon="pen-to-square">
+    The server creates an annotation template with your specified questions.
+    
+    **What happens:**
+    - Annotation questions are defined
+    - Question types are configured (BoundingBox, polygon, etc.)
+    - Template is validated and saved
+    
+    **Example request:**
     ```
     Create an annotation template with bounding boxes for "Car" and "Truck"
     ```
+    
+    **Server response:**
+    ```
+    ✓ Template created: template_xyz789
+    ✓ Questions: Car (BoundingBox), Truck (BoundingBox)
+    ```
   </Step>
   
-  <Step title="Create Project">
-    Link dataset and template:
+  <Step title="Step 3: Create Project" icon="folder-plus">
+    The server links the dataset and template to create your project.
+    
+    **What happens:**
+    - Dataset and template are validated
+    - Project is created with proper configuration
+    - Resources are linked and ready for annotation
+    
+    **Example request:**
     ```
-    Create a project using dataset [dataset_id] and template [template_id]
+    Create a project using dataset dataset_abc123 and template template_xyz789
+    ```
+    
+    **Server response:**
+    ```
+    ✓ Project created: project_final_456
+    ✓ Linked dataset: dataset_abc123 (150 files)
+    ✓ Linked template: template_xyz789
+    ✓ Ready to start annotation!
     ```
   </Step>
 </Steps>
 
-This ensures proper resource management and clear project structure.
+<Tip>
+  **All-in-One Command**: You can also create everything in one natural language request:
+  
+  ```
+  Create an image annotation project called "Vehicle Detection" with 
+  bounding boxes for "Car" and "Truck". Upload images from 
+  /Users/me/vehicles and use my email user@example.com
+  ```
+  
+  The MCP server will automatically execute all three steps and provide you with the final project ID!
+</Tip>
+
+This workflow ensures:
+- ✅ Proper resource management
+- ✅ Clear project structure
+- ✅ Validation at each step
+- ✅ Automatic error handling
 
 ---
 


### PR DESCRIPTION
- Add comprehensive MCP server documentation in sdk/mcp-server.mdx
- Document all 23 MCP tools across 5 categories
- Include quick start guide, configuration examples, and usage patterns
- Add troubleshooting section and advanced features
- Update docs.json navigation to include MCP server page